### PR TITLE
Catching a syntax error in the case that Keen API responds with invalid JSON

### DIFF
--- a/lib/utils/http-server.js
+++ b/lib/utils/http-server.js
@@ -42,14 +42,18 @@ function handleRequest(config, callback){
       body += d;
     });
     res.on('end', function() {
-      var res = JSON.parse(body), error;
-      if (res.error_code) {
-        error = new Error(res.message || 'Unknown error occurred');
-        error.code = res.error_code;
+      try {
+        var parsedBody = JSON.parse(body);
+      } catch (error) {
+        return callback(error, null);
+      }
+      if (parsedBody.error_code) {
+        error = new Error(parsedBody.message || 'Unknown error occurred');
+        error.code = parsedBody.error_code;
         callback(error, null);
       }
       else {
-        callback(null, res);
+        callback(null, parsedBody);
       }
     });
   });


### PR DESCRIPTION
Due to the way that KeenAnalysis implements Promises, failure to catch this error will result in locking the entire thread. 