### PR TITLE
Ignore more webpack files from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,8 @@ test
 .travis.yml
 jest.config.js
 webpack.config.js
+webpack.modules.config.js
+stats.json
 .eslintrc
 
 CHANGELOG.md


### PR DESCRIPTION
stats.json (containing the stats of the webpack build) is one of the biggest files in the package archive, and it brings no value there.