### PR TITLE
Handle certain NULL query results

### DIFF
--- a/lib/utils/http-browser.js
+++ b/lib/utils/http-browser.js
@@ -98,6 +98,7 @@ const sendFetch = (method, config, options = {}) => {
             } else if (responseJSON.result && Array.isArray(responseJSON.result)){
               //interval and group by result
               responseJSON.result.forEach((val) => {
+                if (!val) return;
                 if (!val.value) return val;
                 if (!Array.isArray(val.value)) return val.value;
                 val.value.forEach((res) => {
@@ -111,6 +112,7 @@ const sendFetch = (method, config, options = {}) => {
           else {
             //interval result
             responseJSON.result.forEach((val) => {
+              if (!val) return;
               if(!isNaN(Number(val.value))){
                 val.value = Number(val.value);
               }
@@ -120,6 +122,7 @@ const sendFetch = (method, config, options = {}) => {
         else {
           //group by result
           responseJSON.result.forEach((res) => {
+            if (!res) return;
             if(!isNaN(Number(res.result))){
               res.result = Number(res.result);
             }


### PR DESCRIPTION
Previously, if the Keen API responded with a result having a null entry,
parsing the response would result in a javascript error when this
project checks to see if the result needs to be cast to a Number.

This checks a few possible places were the API might return null, and does
not attempt to cast in these cases. This means null gets passed to the
chart, but in practice this hasn't been an issue. If it is, it could be
handled at the server level or the charting level, but at least this
project won't crash on it.

Note that only [line 123 of current master](https://github.com/keen/keen-analysis.js/blob/32a13c4aa20a3b96cac757cc845f0db20afcf88a/lib/utils/http-browser.js#L123) is failing for me, but this commit changes three places total. The area surrounding line 123, and two other areas that look very similar in roughly the same part of the codebase. These other areas are total guesses, but since clearly this code doesn't expect the API to return null, maybe it's worth doing. 🤷‍♂️I did not try to get every possible place where something is returned from the API here.

Here's a couple screenshots to show what the data looks like to me when this happens. Only one null, right at the end:

<img width="331" alt="Screen Shot 2020-05-12 at 5 35 24 PM" src="https://user-images.githubusercontent.com/25282/81759747-633bb600-947a-11ea-9ad2-98dc0378bad0.png">

<img width="331" alt="Screen Shot 2020-05-12 at 5 34 58 PM" src="https://user-images.githubusercontent.com/25282/81759749-68006a00-947a-11ea-89f0-f217e85116da.png">
